### PR TITLE
feat: Create individual entity page

### DIFF
--- a/entity.html
+++ b/entity.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entity Details</title>
+</head>
+<body>
+    <h2>Previous Test Runs</h2>
+    <ul id="previous-test-runs-list">
+        <!-- Previous test runs will be listed here -->
+    </ul>
+
+    <h2>Current Test Status</h2>
+    <p id="current-test-status">
+        <!-- Current test status will be displayed here -->
+    </p>
+    <script src="entity_script.js"></script>
+</body>
+</html>

--- a/entity_script.js
+++ b/entity_script.js
@@ -1,0 +1,71 @@
+// JavaScript for Entity Details Page
+
+// Function to parse entity ID from URL query parameter
+function getEntityIdFromUrl() {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('id');
+}
+
+// Function to simulate fetching entity data
+function fetchEntityData(entityId) {
+    // Placeholder data - replace with actual API call
+    console.log(`Simulating fetch for entity ID: ${entityId}`);
+    const placeholderData = {
+        previousTestRuns: [
+            { id: "run001", timestamp: "2023-10-26T10:00:00Z", status: "Passed", details: "All checks green." },
+            { id: "run002", timestamp: "2023-10-25T14:30:00Z", status: "Failed", details: "Test 'user_login' failed." },
+            { id: "run003", timestamp: "2023-10-24T09:00:00Z", status: "Passed", details: "Minor UI glitches fixed." }
+        ],
+        currentTestStatus: "No tests currently running."
+    };
+
+    if (entityId === "LIB003") { // Example of entity-specific data
+        placeholderData.currentTestStatus = "Test 'auth_flow' in progress (ETA: 5 mins)";
+        placeholderData.previousTestRuns.unshift(
+             { id: "run004", timestamp: "2023-10-27T11:00:00Z", status: "Running", details: "Initialising..." }
+        );
+    } else if (entityId === "123") {
+         placeholderData.currentTestStatus = "Load tests in progress (ETA: 10 mins)";
+    }
+
+
+    return placeholderData;
+}
+
+// Function to update the page with entity data
+function displayEntityDetails(data) {
+    const previousTestRunsList = document.getElementById('previous-test-runs-list');
+    const currentTestStatusPara = document.getElementById('current-test-status');
+
+    // Clear existing content
+    previousTestRunsList.innerHTML = '';
+
+    // Populate previous test runs
+    if (data.previousTestRuns && data.previousTestRuns.length > 0) {
+        data.previousTestRuns.forEach(run => {
+            const listItem = document.createElement('li');
+            listItem.textContent = `Run ID: ${run.id} - Timestamp: ${run.timestamp} - Status: ${run.status} - Details: ${run.details}`;
+            previousTestRunsList.appendChild(listItem);
+        });
+    } else {
+        const listItem = document.createElement('li');
+        listItem.textContent = "No previous test runs found.";
+        previousTestRunsList.appendChild(listItem);
+    }
+
+    // Populate current test status
+    currentTestStatusPara.textContent = data.currentTestStatus || "Status unknown.";
+}
+
+// Main execution flow on page load
+document.addEventListener('DOMContentLoaded', () => {
+    const entityId = getEntityIdFromUrl();
+    if (entityId) {
+        const entityData = fetchEntityData(entityId);
+        displayEntityDetails(entityData);
+    } else {
+        document.getElementById('previous-test-runs-list').innerHTML = '<li>No entity ID provided in the URL.</li>';
+        document.getElementById('current-test-status').textContent = 'Cannot display status without entity ID.';
+        console.error("No entity ID found in URL.");
+    }
+});

--- a/script.js
+++ b/script.js
@@ -52,9 +52,10 @@ function displayEntities(entityArray) {
     idPara.textContent = `ID: ${entity.id}`;
     entityDiv.appendChild(idPara);
 
-    const namePara = document.createElement('p');
-    namePara.textContent = `Name: ${entity.name}`;
-    entityDiv.appendChild(namePara);
+    const nameLink = document.createElement('a');
+    nameLink.href = `entity.html?id=${entity.id}`;
+    nameLink.textContent = `Name: ${entity.name}`;
+    entityDiv.appendChild(nameLink);
 
     const versionPara = document.createElement('p');
     versionPara.textContent = `Version: ${entity.version}`;

--- a/style.css
+++ b/style.css
@@ -71,3 +71,42 @@ h1 {
   color: #f39c12; /* Orange */
   font-weight: bold;
 }
+
+/* Styles for entity.html */
+h2 {
+  color: #34495e;
+  margin-top: 30px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #bdc3c7;
+  padding-bottom: 5px;
+}
+
+#previous-test-runs-list {
+  list-style-type: square;
+  margin-left: 20px;
+  padding-left: 10px;
+  background-color: #ffffff;
+  border: 1px solid #eeeeee;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+#previous-test-runs-list li {
+  margin-bottom: 8px;
+  padding: 5px;
+  border-bottom: 1px dashed #f0f0f0;
+}
+
+#previous-test-runs-list li:last-child {
+  border-bottom: none;
+}
+
+#current-test-status {
+  font-weight: bold;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: #e9ecef;
+  border-left: 4px solid #7f8c8d;
+  border-radius: 4px;
+}


### PR DESCRIPTION
This commit introduces the individual entity page (`entity.html`) as outlined in item 2 of your TODO.md file.

The new page includes:
- Placeholders for a list of all previous test runs.
- Placeholders for the status of currently running tests.

Key changes:
- Added `entity.html` with the basic structure for displaying entity-specific test information.
- Created `entity_script.js` to handle:
    - Parsing the entity ID from the URL.
    - Populating the page with placeholder data for previous test runs and current test status.
- Updated `script.js` on the main page (`index.html`) to link each entity to its corresponding `entity.html?id=<entityId>` page.
- Added basic styling to `style.css` for the new elements on `entity.html` to improve presentation.